### PR TITLE
fix(dashboard): use safe filter for mindmap rendering

### DIFF
--- a/dashboard/templates/paper.html
+++ b/dashboard/templates/paper.html
@@ -134,7 +134,7 @@
         <div class="card-body p-2" style="height: 500px;">
           <div class="markmap" style="width: 100%; height: 100%;">
             <script type="text/template">
-{{ mindmap }}
+{{ mindmap | safe }}
             </script>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Apply `| safe` filter to `{{ mindmap }}` in `paper.html` to prevent Jinja2 autoescape from converting markdown characters to HTML entities
- Mindmap content is from local `.mindmap.md` files (not user input), so skipping escape is safe

## Root Cause
Jinja2 autoescape converts `<`, `>`, `&` to `&lt;`, `&gt;`, `&amp;`, breaking Markmap's markdown parsing.

## Test plan
- [x] `pytest -v` — all 21 tests pass
- [ ] Open any paper detail page and verify the mindmap renders as an interactive tree (not raw HTML entities)
- [ ] Verify expand/collapse works on mindmap nodes
- [ ] Check all 8 papers with mindmap files

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)