### PR TITLE
feat(graph): add paper citation graph with D3.js

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "papers"
@@ -53,6 +53,42 @@ def compute_stats(papers: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def build_graph_data(papers: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build nodes and links for D3.js force-directed graph."""
+    arxiv_map: dict[str, dict[str, Any]] = {}
+    for p in papers:
+        aid = p.get("arxiv_id")
+        if aid:
+            arxiv_map[aid] = p
+
+    nodes = [
+        {
+            "id": p["id"],
+            "name": p.get("title", "")[:30],
+            "arxiv_id": p.get("arxiv_id"),
+        }
+        for p in papers
+    ]
+
+    links: list[dict[str, str]] = []
+    for p in papers:
+        for ref in p.get("key_references", []):
+            target_arxiv = ref.get("arxiv_id")
+            if not target_arxiv:
+                continue
+            target_paper = arxiv_map.get(target_arxiv)
+            if target_paper:
+                links.append(
+                    {
+                        "source": p["id"],
+                        "target": target_paper["id"],
+                        "relationship": ref.get("relationship", "extends"),
+                    }
+                )
+
+    return {"nodes": nodes, "links": links}
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -74,8 +110,10 @@ async def paper_detail(request: Request, paper_id: str) -> HTMLResponse:
     if paper is None:
         return HTMLResponse("<h1>Paper not found</h1>", status_code=404)
     mindmap = load_mindmap(paper_id)
+    arxiv_map = {p["arxiv_id"]: p for p in papers if p.get("arxiv_id")}
     return templates.TemplateResponse(
-        "paper.html", {"request": request, "paper": paper, "mindmap": mindmap}
+        "paper.html",
+        {"request": request, "paper": paper, "mindmap": mindmap, "arxiv_map": arxiv_map},
     )
 
 
@@ -94,3 +132,15 @@ async def frag_stats(request: Request) -> HTMLResponse:
     return templates.TemplateResponse(
         "_stats.html", {"request": request, "stats": stats}
     )
+
+
+@app.get("/graph", response_class=HTMLResponse)
+async def graph(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse("graph.html", {"request": request})
+
+
+@app.get("/api/graph-data")
+async def graph_data() -> JSONResponse:
+    papers = load_papers()
+    data = build_graph_data(papers)
+    return JSONResponse(data)

--- a/dashboard/templates/graph.html
+++ b/dashboard/templates/graph.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Paper Graph — Research Hub</title>
+  <link href="https://cdn.jsdelivr.net/npm/daisyui@4/dist/full.min.css" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+</head>
+<body class="min-h-screen bg-base-200">
+
+  <div class="navbar bg-base-100 shadow-lg">
+    <a href="./" class="btn btn-ghost text-xl">Research Hub</a>
+    <a href="./graph" class="btn btn-ghost btn-sm">Graph</a>
+  </div>
+
+  <div class="container mx-auto px-4 py-8 max-w-6xl">
+    <h1 class="text-2xl font-bold mb-4">Paper Graph</h1>
+
+    <!-- Legend -->
+    <div class="flex flex-wrap gap-4 mb-4 text-sm">
+      <span class="flex items-center gap-1">
+        <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="#60a5fa" stroke-width="2"/></svg>
+        extends
+      </span>
+      <span class="flex items-center gap-1">
+        <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,3"/></svg>
+        builds_on
+      </span>
+      <span class="flex items-center gap-1">
+        <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="#60a5fa" stroke-width="2" stroke-dasharray="2,3"/></svg>
+        compares
+      </span>
+    </div>
+
+    <div class="card bg-base-100 shadow">
+      <div class="card-body p-2">
+        <svg id="graph-svg" width="100%" height="600"></svg>
+      </div>
+    </div>
+  </div>
+
+<script>
+(async function() {
+  const resp = await fetch('./api/graph-data');
+  const data = await resp.json();
+
+  if (data.nodes.length === 0) {
+    document.getElementById('graph-svg').innerHTML =
+      '<text x="50%" y="50%" text-anchor="middle" fill="#888" font-size="16">No papers yet.</text>';
+    return;
+  }
+
+  const svg = d3.select('#graph-svg');
+  const width = svg.node().getBoundingClientRect().width;
+  const height = 600;
+
+  svg.attr('viewBox', [0, 0, width, height]);
+
+  // Count incoming references per node for sizing
+  const inDegree = {};
+  data.nodes.forEach(n => { inDegree[n.id] = 0; });
+  data.links.forEach(l => {
+    inDegree[l.target] = (inDegree[l.target] || 0) + 1;
+  });
+
+  // Arrow markers
+  const defs = svg.append('defs');
+  defs.append('marker')
+    .attr('id', 'arrow')
+    .attr('viewBox', '0 -5 10 10')
+    .attr('refX', 20)
+    .attr('refY', 0)
+    .attr('markerWidth', 6)
+    .attr('markerHeight', 6)
+    .attr('orient', 'auto')
+    .append('path')
+    .attr('d', 'M0,-5L10,0L0,5')
+    .attr('fill', '#60a5fa');
+
+  // Edge style helper
+  function strokeDash(rel) {
+    if (rel === 'builds_on') return '6,3';
+    if (rel === 'compares') return '2,3';
+    return null; // solid for extends
+  }
+
+  const simulation = d3.forceSimulation(data.nodes)
+    .force('link', d3.forceLink(data.links).id(d => d.id).distance(120))
+    .force('charge', d3.forceManyBody().strength(-300))
+    .force('center', d3.forceCenter(width / 2, height / 2))
+    .force('collide', d3.forceCollide(40));
+
+  const link = svg.append('g')
+    .selectAll('line')
+    .data(data.links)
+    .join('line')
+    .attr('stroke', '#60a5fa')
+    .attr('stroke-width', 1.5)
+    .attr('stroke-dasharray', d => strokeDash(d.relationship))
+    .attr('marker-end', 'url(#arrow)');
+
+  const node = svg.append('g')
+    .selectAll('g')
+    .data(data.nodes)
+    .join('g')
+    .attr('cursor', 'pointer')
+    .on('click', (event, d) => {
+      window.location.href = './paper/' + d.id;
+    })
+    .call(d3.drag()
+      .on('start', (event, d) => {
+        if (!event.active) simulation.alphaTarget(0.3).restart();
+        d.fx = d.x; d.fy = d.y;
+      })
+      .on('drag', (event, d) => {
+        d.fx = event.x; d.fy = event.y;
+      })
+      .on('end', (event, d) => {
+        if (!event.active) simulation.alphaTarget(0);
+        d.fx = null; d.fy = null;
+      })
+    );
+
+  node.append('circle')
+    .attr('r', d => 8 + (inDegree[d.id] || 0) * 3)
+    .attr('fill', '#3b82f6')
+    .attr('stroke', '#93c5fd')
+    .attr('stroke-width', 1.5);
+
+  node.append('text')
+    .text(d => d.name)
+    .attr('dy', d => -(12 + (inDegree[d.id] || 0) * 3))
+    .attr('text-anchor', 'middle')
+    .attr('fill', '#e2e8f0')
+    .attr('font-size', '12px');
+
+  // Tooltip on hover
+  node.append('title').text(d => d.name);
+
+  simulation.on('tick', () => {
+    link
+      .attr('x1', d => d.source.x)
+      .attr('y1', d => d.source.y)
+      .attr('x2', d => d.target.x)
+      .attr('y2', d => d.target.y);
+    node.attr('transform', d => `translate(${d.x},${d.y})`);
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -12,6 +12,7 @@
 
   <div class="navbar bg-base-100 shadow-lg">
     <a href="./" class="btn btn-ghost text-xl">Research Hub</a>
+    <a href="./graph" class="btn btn-ghost btn-sm">Graph</a>
   </div>
 
   <div class="container mx-auto px-4 py-8 max-w-6xl">

--- a/dashboard/templates/paper.html
+++ b/dashboard/templates/paper.html
@@ -11,6 +11,7 @@
 
   <div class="navbar bg-base-100 shadow-lg">
     <a href="../" class="btn btn-ghost text-xl">Research Hub</a>
+    <a href="../graph" class="btn btn-ghost btn-sm">Graph</a>
   </div>
 
   <div class="container mx-auto px-4 py-8 max-w-4xl">
@@ -120,7 +121,14 @@
       <h2 class="text-xl font-bold mb-3">Key References</h2>
       <ul class="list-disc list-inside space-y-1 text-sm">
         {% for ref in paper.key_references %}
-        <li>{{ ref.title }} <span class="badge badge-ghost badge-xs">{{ ref.relationship }}</span></li>
+        <li>
+          {% if ref.arxiv_id and arxiv_map.get(ref.arxiv_id) %}
+          <a href="../paper/{{ arxiv_map[ref.arxiv_id].id }}" class="link link-primary">{{ ref.title }}</a>
+          {% else %}
+          {{ ref.title }}
+          {% endif %}
+          <span class="badge badge-ghost badge-xs">{{ ref.relationship }}</span>
+        </li>
         {% endfor %}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- Add `/graph` page with D3.js force-directed graph showing paper citation relationships (extends/builds_on/compares)
- Add `/api/graph-data` JSON endpoint that builds graph nodes and links from paper `key_references`
- Add "Graph" link to navbar on all pages (index, paper detail, graph)
- Link Key References in paper detail to in-library papers when `arxiv_id` matches

## Details
- Edge styles distinguish relationship types: solid (extends), dashed (builds_on), dotted (compares)
- Node size scales by incoming reference count
- Click any node to navigate to paper detail page
- Draggable nodes with force simulation
- Dark theme consistent with existing dashboard
- D3.js loaded via CDN (`https://cdn.jsdelivr.net/npm/d3@7`)
- Only connects papers that exist in the library; unmatched references are excluded

## Test plan
- [x] `pytest -v` — 21 tests pass
- [ ] Open `/graph` and verify D3.js force-directed graph renders
- [ ] Verify edge styles differ by relationship type
- [ ] Click a node and confirm navigation to `/paper/<id>`
- [ ] Check navbar "Graph" link appears on index, paper detail, and graph pages
- [ ] Add a paper with `key_references` pointing to existing library papers and verify links appear

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)