### PR TITLE
feat(dashboard): add search, tag filtering, and enhanced paper cards

### DIFF
--- a/dashboard/templates/_paper_list.html
+++ b/dashboard/templates/_paper_list.html
@@ -1,13 +1,32 @@
-<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4" id="paper-grid">
   {% for paper in papers %}
-  <a href="paper/{{ paper.id }}" class="card bg-base-100 shadow-md hover:shadow-xl transition-shadow cursor-pointer">
-    <div class="card-body">
-      <h3 class="card-title text-base">{{ paper.title }}</h3>
+  <a href="paper/{{ paper.id }}"
+     class="paper-card card bg-base-100 shadow-md hover:shadow-xl transition-shadow cursor-pointer"
+     data-title="{{ paper.title | lower }}"
+     data-oneliner="{{ (paper.summary.one_liner if paper.summary and paper.summary.one_liner else '') | lower }}"
+     data-tags="{{ paper.tags | join(',') | lower }}">
+    <div class="card-body p-4 gap-1">
+      <h3 class="card-title text-base leading-snug">{{ paper.title }}</h3>
+      {% if paper.authors %}
+      <p class="text-xs opacity-60">{{ paper.authors[0] }}{% if paper.authors | length > 1 %} et al.{% endif %}</p>
+      {% endif %}
       {% if paper.summary and paper.summary.one_liner %}
-      <p class="text-sm opacity-70">{{ paper.summary.one_liner }}</p>
+      <p class="text-sm opacity-70 line-clamp-2">{{ paper.summary.one_liner }}</p>
+      {% endif %}
+      {% if paper.benchmarks %}
+      <div class="flex flex-wrap gap-2 mt-1">
+        {% for bm in paper.benchmarks[:2] %}
+        <span class="badge badge-sm badge-accent badge-outline">{{ bm.dataset }}: {{ bm.score }}</span>
+        {% endfor %}
+      </div>
       {% endif %}
       <div class="card-actions justify-between items-center mt-2">
-        <span class="text-xs opacity-50">{{ paper.date }}</span>
+        <div class="flex items-center gap-2">
+          <span class="text-xs opacity-50">{{ paper.date }}</span>
+          {% if paper.key_references %}
+          <span class="text-xs opacity-50">· {{ paper.key_references | length }} ref{{ 's' if paper.key_references | length != 1 else '' }}</span>
+          {% endif %}
+        </div>
         <div class="flex flex-wrap gap-1">
           {% for tag in paper.tags[:3] %}
           <span class="badge badge-sm badge-primary badge-outline">{{ tag }}</span>

--- a/dashboard/templates/_stats.html
+++ b/dashboard/templates/_stats.html
@@ -10,9 +10,9 @@
 </div>
 
 {% if stats.tags %}
-<div class="flex flex-wrap gap-2 mt-4">
+<div class="flex flex-wrap gap-2 mt-4" id="tag-filter">
   {% for tag, count in stats.tags %}
-  <div class="badge badge-outline badge-lg gap-1">{{ tag }}<span class="text-xs opacity-60">{{ count }}</span></div>
+  <button type="button" class="tag-btn badge badge-outline badge-lg gap-1 cursor-pointer" data-tag="{{ tag | lower }}">{{ tag }}<span class="text-xs opacity-60">{{ count }}</span></button>
   {% endfor %}
 </div>
 {% endif %}

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -24,11 +24,83 @@
 
     <!-- Paper List -->
     <h2 class="text-2xl font-bold mt-8 mb-4">Papers</h2>
+
+    <input type="text" id="search-input" placeholder="Search papers…"
+           class="input input-bordered w-full mb-4" />
+
     <div id="paper-list" hx-get="frag/papers" hx-trigger="load" hx-swap="innerHTML">
       {% include '_paper_list.html' %}
     </div>
 
+    <div id="no-results" class="hidden text-center py-12 opacity-50">No matching papers.</div>
+
   </div>
+
+  <script>
+  (function() {
+    let activeTag = null;
+
+    function filterPapers() {
+      const query = (document.getElementById('search-input').value || '').toLowerCase().trim();
+      const cards = document.querySelectorAll('.paper-card');
+      let visible = 0;
+
+      cards.forEach(function(card) {
+        const title = card.getAttribute('data-title') || '';
+        const oneliner = card.getAttribute('data-oneliner') || '';
+        const tags = card.getAttribute('data-tags') || '';
+
+        const matchesSearch = !query ||
+          title.indexOf(query) !== -1 ||
+          oneliner.indexOf(query) !== -1 ||
+          tags.indexOf(query) !== -1;
+
+        const matchesTag = !activeTag || tags.split(',').indexOf(activeTag) !== -1;
+
+        if (matchesSearch && matchesTag) {
+          card.style.display = '';
+          visible++;
+        } else {
+          card.style.display = 'none';
+        }
+      });
+
+      var noResults = document.getElementById('no-results');
+      if (noResults) {
+        noResults.classList.toggle('hidden', visible > 0);
+      }
+    }
+
+    // Search input
+    document.getElementById('search-input').addEventListener('input', filterPapers);
+
+    // Tag click delegation
+    document.addEventListener('click', function(e) {
+      var btn = e.target.closest('.tag-btn');
+      if (!btn) return;
+
+      var tag = btn.getAttribute('data-tag');
+      if (activeTag === tag) {
+        activeTag = null;
+      } else {
+        activeTag = tag;
+      }
+
+      // Update all tag button styles
+      document.querySelectorAll('.tag-btn').forEach(function(b) {
+        if (b.getAttribute('data-tag') === activeTag) {
+          b.classList.remove('badge-outline');
+          b.classList.add('badge-primary');
+        } else {
+          b.classList.add('badge-outline');
+          b.classList.remove('badge-primary');
+        }
+      });
+
+      filterPapers();
+    });
+  })();
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add real-time search box that filters papers by title, one_liner, and tags
- Make tag badges clickable for filtering with active tag highlight (`badge-primary`)
- Enhance paper cards: first author + et al., top-2 benchmark scores, reference count
- Search and tag filter combine (AND logic), pure frontend JS — no new backend routes

## Changed files
- `dashboard/templates/index.html` — search input + filter JS
- `dashboard/templates/_paper_list.html` — data attributes + card info enhancements
- `dashboard/templates/_stats.html` — clickable tag buttons

## Test plan
- [x] `pytest -v` — 21/21 passed
- [ ] Manual: type in search box → cards filter in real-time
- [ ] Manual: click a tag → only matching papers shown, badge highlights
- [ ] Manual: click same tag again → filter clears
- [ ] Manual: search + tag filter combine correctly
- [ ] Manual: Graph link still works

Part of #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)