### PR TITLE
fix(dashboard): set markmap SVG to fill container dimensions

### DIFF
--- a/dashboard/templates/paper.html
+++ b/dashboard/templates/paper.html
@@ -6,6 +6,10 @@
   <title>{{ paper.title }} — Research Hub</title>
   <link href="https://cdn.jsdelivr.net/npm/daisyui@4/dist/full.min.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    .markmap { position: relative; }
+    .markmap > svg { width: 100%; height: 100%; }
+  </style>
 </head>
 <body class="min-h-screen bg-base-200">
 


### PR DESCRIPTION
## Summary
- Add CSS rules for `.markmap` (`position: relative`) and `.markmap > svg` (`width: 100%; height: 100%`) so the markmap SVG fills the 500px parent container
- The markmap autoloader creates SVGs without explicit dimensions, causing them to render as a tiny block

## Test plan
- [x] `pytest -v` — 21/21 passed
- [ ] Open a paper detail page with a mindmap and verify the SVG fills the 500px card

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)