### PR TITLE
fix(dashboard): make mindmap text visible in dark theme

### DIFF
--- a/dashboard/templates/paper.html
+++ b/dashboard/templates/paper.html
@@ -9,6 +9,8 @@
   <style>
     .markmap { position: relative; }
     .markmap > svg { width: 100%; height: 100%; }
+    .markmap > svg { color: #e2e8f0; }
+    .markmap > svg text { fill: #e2e8f0 !important; }
   </style>
 </head>
 <body class="min-h-screen bg-base-200">


### PR DESCRIPTION
## Summary
- Set markmap SVG text color to `#e2e8f0` so mindmap labels are readable on dark backgrounds
- Added two CSS rules to the existing `<style>` block in `paper.html`

Closes #13

## Test plan
- [x] `pytest -v` — 21/21 passed
- [ ] Visual check: open a paper page with a mindmap and confirm text is legible in dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)