### PR TITLE
feat(dashboard): paper detail nav and responsive fixes

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -111,9 +111,22 @@ async def paper_detail(request: Request, paper_id: str) -> HTMLResponse:
         return HTMLResponse("<h1>Paper not found</h1>", status_code=404)
     mindmap = load_mindmap(paper_id)
     arxiv_map = {p["arxiv_id"]: p for p in papers if p.get("arxiv_id")}
+
+    # Compute prev/next papers (papers are sorted newest-first)
+    idx = next(i for i, p in enumerate(papers) if p.get("id") == paper_id)
+    prev_paper = papers[idx - 1] if idx > 0 else None
+    next_paper = papers[idx + 1] if idx < len(papers) - 1 else None
+
     return templates.TemplateResponse(
         "paper.html",
-        {"request": request, "paper": paper, "mindmap": mindmap, "arxiv_map": arxiv_map},
+        {
+            "request": request,
+            "paper": paper,
+            "mindmap": mindmap,
+            "arxiv_map": arxiv_map,
+            "prev_paper": prev_paper,
+            "next_paper": next_paper,
+        },
     )
 
 

--- a/dashboard/templates/graph.html
+++ b/dashboard/templates/graph.html
@@ -7,6 +7,11 @@
   <link href="https://cdn.jsdelivr.net/npm/daisyui@4/dist/full.min.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+  <style>
+    @media (max-width: 767px) {
+      #graph-svg { height: 400px; }
+    }
+  </style>
 </head>
 <body class="min-h-screen bg-base-200">
 
@@ -54,7 +59,7 @@
 
   const svg = d3.select('#graph-svg');
   const width = svg.node().getBoundingClientRect().width;
-  const height = 600;
+  const height = svg.node().getBoundingClientRect().height;
 
   svg.attr('viewBox', [0, 0, width, height]);
 

--- a/dashboard/templates/paper.html
+++ b/dashboard/templates/paper.html
@@ -20,6 +20,20 @@
 
   <div class="container mx-auto px-4 py-8 max-w-4xl">
 
+    <!-- Top Navigation -->
+    <div class="flex justify-between mb-4">
+      {% if prev_paper %}
+      <a href="../paper/{{ prev_paper.id }}" class="btn btn-outline btn-sm">&larr; Previous</a>
+      {% else %}
+      <span></span>
+      {% endif %}
+      {% if next_paper %}
+      <a href="../paper/{{ next_paper.id }}" class="btn btn-outline btn-sm">Next &rarr;</a>
+      {% else %}
+      <span></span>
+      {% endif %}
+    </div>
+
     <!-- Header -->
     <h1 class="text-3xl font-bold mb-2">{{ paper.title }}</h1>
     <div class="flex flex-wrap items-center gap-3 mb-6 text-sm opacity-70">
@@ -154,6 +168,20 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/markmap-autoloader"></script>
     {% endif %}
+
+    <!-- Bottom Navigation -->
+    <div class="flex justify-between mt-8 pt-4 border-t border-base-300">
+      {% if prev_paper %}
+      <a href="../paper/{{ prev_paper.id }}" class="btn btn-outline btn-sm">&larr; Previous</a>
+      {% else %}
+      <span></span>
+      {% endif %}
+      {% if next_paper %}
+      <a href="../paper/{{ next_paper.id }}" class="btn btn-outline btn-sm">Next &rarr;</a>
+      {% else %}
+      <span></span>
+      {% endif %}
+    </div>
 
   </div>
 


### PR DESCRIPTION
## Summary
- Add prev/next paper navigation buttons at top and bottom of paper detail page
- Buttons hidden at list boundaries (no "Previous" on newest, no "Next" on oldest)
- Responsive graph SVG height (400px on mobile, 600px on desktop)
- Uses DaisyUI `btn btn-outline btn-sm` styling

## Test plan
- [x] pytest -v — 21/21 passed
- [ ] Verify prev/next buttons appear on detail page and link correctly
- [ ] Verify buttons hidden on first/last paper
- [ ] Verify graph SVG shrinks on viewport < 768px
- [ ] Verify paper cards single-column on mobile

Part of #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)