### PR TITLE
fix(rag): return retrieved context from dummy_llm instead of empty string

### DIFF
--- a/rag/engine.py
+++ b/rag/engine.py
@@ -30,8 +30,19 @@ async def local_embed(texts: list[str]) -> np.ndarray:
 
 
 async def dummy_llm(prompt: str, **kwargs: object) -> str:
-    """Dummy LLM — naive mode does not use entity extraction."""
-    return ""
+    """Return retrieved context directly — no real LLM synthesis.
+
+    LightRAG passes retrieved chunks via ``system_prompt``.  We surface that
+    content as-is so naive-mode queries return meaningful results without
+    requiring an external LLM.
+    """
+    system_prompt = kwargs.get("system_prompt", "")
+    if system_prompt:
+        marker = "-----Contexts-----"
+        if marker in system_prompt:
+            return system_prompt.split(marker, 1)[1].strip()
+        return system_prompt
+    return prompt
 
 
 def create_rag() -> LightRAG:


### PR DESCRIPTION
## Summary

- `dummy_llm` was returning `""`, causing LightRAG naive-mode `/search-kg` queries to always produce empty results even when embedding retrieval found matching chunks
- Now reads `system_prompt` from kwargs (where LightRAG passes retrieved chunks) and returns the content after the `"-----Contexts-----"` marker, falling back to the full `system_prompt` or the original `prompt` if neither is present

## Test plan

- [ ] `pytest tests/ -v` — all 34 tests pass
- [ ] Manual: POST `/api/search-kg` with a real question returns non-empty results

Part of #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)