### PR TITLE
fix(rag): extract context from LightRAG system_prompt in dummy_llm

### DIFF
--- a/rag/engine.py
+++ b/rag/engine.py
@@ -30,8 +30,20 @@ async def local_embed(texts: list[str]) -> np.ndarray:
 
 
 async def dummy_llm(prompt: str, **kwargs: object) -> str:
-    """Dummy LLM — naive mode does not use entity extraction."""
-    return ""
+    """Return retrieved context directly — no real LLM synthesis.
+
+    LightRAG passes retrieved chunks via ``system_prompt``.  We surface
+    the context portion so naive-mode queries return meaningful results
+    without requiring an external LLM.
+    """
+    system_prompt = kwargs.get("system_prompt", "")
+    if system_prompt:
+        # LightRAG uses "---Context---" (3 dashes, singular) as marker
+        marker = "---Context---"
+        if marker in system_prompt:
+            return system_prompt.split(marker, 1)[1].strip()
+        return system_prompt
+    return prompt
 
 
 def create_rag() -> LightRAG:

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from rag.engine import dummy_llm
 from rag.ingest import format_paper_text
 
 VESPO_PATH = Path(__file__).resolve().parent.parent / "data" / "papers" / "2026-02-11_2602.10693.json"
@@ -14,6 +15,35 @@ VESPO_PATH = Path(__file__).resolve().parent.parent / "data" / "papers" / "2026-
 @pytest.fixture
 def vespo_dict() -> dict:
     return json.loads(VESPO_PATH.read_text())
+
+
+class TestDummyLlm:
+    @pytest.fixture
+    def anyio_backend(self):
+        return "asyncio"
+
+    @pytest.mark.anyio
+    async def test_extracts_context_after_marker(self):
+        system_prompt = "---Role---\nYou are...\n---Context---\nChunk data here"
+        result = await dummy_llm("question", system_prompt=system_prompt)
+        assert result == "Chunk data here"
+        assert "---Role---" not in result
+
+    @pytest.mark.anyio
+    async def test_returns_full_system_prompt_without_marker(self):
+        system_prompt = "Some context without marker"
+        result = await dummy_llm("question", system_prompt=system_prompt)
+        assert result == system_prompt
+
+    @pytest.mark.anyio
+    async def test_returns_prompt_when_no_system_prompt(self):
+        result = await dummy_llm("my question")
+        assert result == "my question"
+
+    @pytest.mark.anyio
+    async def test_returns_prompt_when_empty_system_prompt(self):
+        result = await dummy_llm("my question", system_prompt="")
+        assert result == "my question"
 
 
 class TestFormatPaperText:


### PR DESCRIPTION
## Summary

- `dummy_llm` previously returned `""`, causing all `/search-kg` naive-mode queries to yield empty results
- Now extracts content after the `---Context---` marker from the `system_prompt` LightRAG injects, surfacing retrieved chunks without an external LLM
- Falls back to the full system_prompt if the marker is absent, or the original prompt if no system_prompt is provided

## Test plan

- [ ] `TestDummyLlm::test_extracts_context_after_marker` — verifies marker splitting and that role section is excluded
- [ ] `TestDummyLlm::test_returns_full_system_prompt_without_marker` — fallback when marker absent
- [ ] `TestDummyLlm::test_returns_prompt_when_no_system_prompt` — no kwargs case
- [ ] `TestDummyLlm::test_returns_prompt_when_empty_system_prompt` — empty string case
- [ ] `pytest tests/ -v` — 38 passed

Part of #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)