### PR TITLE
feat(search): render search results as structured paper cards

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections import Counter
 from pathlib import Path
 from typing import Any
@@ -165,6 +166,61 @@ async def search_kg_page(request: Request) -> HTMLResponse:
     return templates.TemplateResponse("search_kg.html", {"request": request})
 
 
+def parse_content_string(content: str) -> dict | None:
+    """Parse a 'Title: X\nAuthors: Y\n...' content string into a dict."""
+    if not content:
+        return None
+    result: dict[str, Any] = {}
+    for line in content.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("Title: "):
+            result["title"] = line[7:]
+        elif line.startswith("Authors: "):
+            result["authors"] = line[9:]
+        elif line.startswith("Date: "):
+            result["date"] = line[6:]
+        elif line.startswith("Summary: "):
+            result["summary"] = line[9:]
+        elif line.startswith("Problem: "):
+            result["problem"] = line[9:]
+        elif line.startswith("Method: "):
+            result["method"] = line[8:]
+        elif line.startswith("Innovation: "):
+            result["innovation"] = line[12:]
+        elif line.startswith("Results: "):
+            result["results"] = line[9:]
+        elif line.startswith("Tags: "):
+            result["tags"] = [t.strip() for t in line[6:].split(",")]
+        elif line.startswith("Benchmark: "):
+            result.setdefault("benchmarks", []).append(line[11:])
+    return result if result.get("title") else None
+
+
+def parse_search_results(raw: str) -> list[dict]:
+    """Parse LightRAG raw output into structured paper chunks."""
+    if not raw or not raw.strip():
+        return []
+
+    json_match = re.search(r"```json\s*(.*?)```", raw, re.DOTALL)
+    if json_match:
+        json_text = json_match.group(1).strip()
+        chunks = []
+        for match in re.finditer(r'\{[^{}]*"content"[^{}]*\}', json_text, re.DOTALL):
+            try:
+                obj = json.loads(match.group())
+                chunk = parse_content_string(obj.get("content", ""))
+                if chunk:
+                    chunks.append(chunk)
+            except json.JSONDecodeError:
+                continue
+        if chunks:
+            return chunks
+
+    return [{"title": "Search Results", "summary": raw[:500]}]
+
+
 @app.post("/api/search-kg")
 async def api_search_kg(request: Request) -> JSONResponse:
     body = await request.json()
@@ -177,6 +233,7 @@ async def api_search_kg(request: Request) -> JSONResponse:
     await rag.initialize_storages()
     try:
         result = await rag.aquery(question, param=QueryParam(mode="naive"))
-        return JSONResponse({"results": result})
+        papers = parse_search_results(result)
+        return JSONResponse({"results": papers})
     finally:
         await rag.finalize_storages()

--- a/dashboard/templates/search_kg.html
+++ b/dashboard/templates/search_kg.html
@@ -28,13 +28,9 @@
       <span class="loading loading-spinner loading-lg"></span>
     </div>
 
-    <div id="results" class="hidden">
+    <div id="results" class="hidden space-y-4">
       <h2 class="text-lg font-semibold mb-3">Results</h2>
-      <div id="results-content" class="card bg-base-100 shadow">
-        <div class="card-body">
-          <p id="results-text" class="whitespace-pre-wrap text-sm"></p>
-        </div>
-      </div>
+      <div id="results-content"></div>
     </div>
 
     <div id="empty" class="hidden text-center py-8 opacity-50">
@@ -48,8 +44,68 @@
   var btn = document.getElementById('search-btn');
   var loading = document.getElementById('loading');
   var results = document.getElementById('results');
-  var resultsText = document.getElementById('results-text');
+  var resultsContent = document.getElementById('results-content');
   var empty = document.getElementById('empty');
+
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function renderResults(papers) {
+    resultsContent.innerHTML = '';
+    papers.forEach(function(p) {
+      var card = document.createElement('div');
+      card.className = 'card bg-base-100 shadow mb-3';
+
+      var body = document.createElement('div');
+      body.className = 'card-body p-4';
+
+      var title = document.createElement('h3');
+      title.className = 'card-title text-base';
+      title.textContent = p.title || 'Untitled';
+      body.appendChild(title);
+
+      if (p.date || p.authors) {
+        var meta = document.createElement('p');
+        meta.className = 'text-xs opacity-60 mb-2';
+        meta.textContent = [p.date, p.authors].filter(Boolean).join(' · ');
+        body.appendChild(meta);
+      }
+
+      if (p.summary) {
+        var summary = document.createElement('p');
+        summary.className = 'text-sm mb-2';
+        summary.textContent = p.summary;
+        body.appendChild(summary);
+      }
+
+      if (p.tags && p.tags.length) {
+        var tagDiv = document.createElement('div');
+        tagDiv.className = 'flex flex-wrap gap-1 mt-2';
+        p.tags.forEach(function(t) {
+          var badge = document.createElement('span');
+          badge.className = 'badge badge-outline badge-xs';
+          badge.textContent = t;
+          tagDiv.appendChild(badge);
+        });
+        body.appendChild(tagDiv);
+      }
+
+      if (p.benchmarks && p.benchmarks.length) {
+        var benchDiv = document.createElement('div');
+        benchDiv.className = 'mt-2 text-xs opacity-70';
+        benchDiv.textContent = p.benchmarks.join(' | ');
+        body.appendChild(benchDiv);
+      }
+
+      card.appendChild(body);
+      resultsContent.appendChild(card);
+    });
+  }
 
   async function doSearch() {
     var question = input.value.trim();
@@ -68,13 +124,17 @@
       });
       var data = await resp.json();
       if (data.results && data.results.length > 0) {
-        resultsText.textContent = typeof data.results === 'string' ? data.results : JSON.stringify(data.results, null, 2);
+        if (Array.isArray(data.results)) {
+          renderResults(data.results);
+        } else {
+          resultsContent.innerHTML = '<div class="card bg-base-100 shadow"><div class="card-body"><p class="whitespace-pre-wrap text-sm">' + escapeHtml(data.results) + '</p></div></div>';
+        }
         results.classList.remove('hidden');
       } else {
         empty.classList.remove('hidden');
       }
     } catch (err) {
-      resultsText.textContent = 'Error: ' + err.message;
+      resultsContent.innerHTML = '<div class="card bg-base-100 shadow"><div class="card-body"><p class="text-sm text-error">Error: ' + escapeHtml(err.message) + '</p></div></div>';
       results.classList.remove('hidden');
     } finally {
       loading.classList.add('hidden');

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -8,6 +8,7 @@ import pytest
 
 from rag.engine import dummy_llm
 from rag.ingest import format_paper_text
+from dashboard.app import parse_content_string, parse_search_results
 
 VESPO_PATH = Path(__file__).resolve().parent.parent / "data" / "papers" / "2026-02-11_2602.10693.json"
 
@@ -113,10 +114,107 @@ class TestSearchKGRoute:
 
     @patch("rag.engine.create_rag")
     def test_search_kg_with_question(self, mock_create_rag, client) -> None:
+        raw = (
+            "```json\n"
+            '{"reference_id": "", "content": "Title: VESPO\\nAuthors: A\\nDate: 2026-01-01\\nSummary: A variational framework"}\n'
+            "```"
+        )
+        mock_rag = AsyncMock()
+        mock_rag.aquery.return_value = raw
+        mock_create_rag.return_value = mock_rag
+
+        resp = client.post("/api/search-kg", json={"question": "What is VESPO?"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data["results"], list)
+        assert len(data["results"]) == 1
+        assert data["results"][0]["title"] == "VESPO"
+        assert data["results"][0]["summary"] == "A variational framework"
+
+    @patch("rag.engine.create_rag")
+    def test_search_kg_fallback_for_plain_text(self, mock_create_rag, client) -> None:
         mock_rag = AsyncMock()
         mock_rag.aquery.return_value = "VESPO uses variational framework"
         mock_create_rag.return_value = mock_rag
 
         resp = client.post("/api/search-kg", json={"question": "What is VESPO?"})
         assert resp.status_code == 200
-        assert resp.json() == {"results": "VESPO uses variational framework"}
+        data = resp.json()
+        assert isinstance(data["results"], list)
+        assert data["results"][0]["title"] == "Search Results"
+
+
+class TestParseContentString:
+    def test_full_entry(self) -> None:
+        content = (
+            "Title: My Paper\nAuthors: Alice, Bob\nDate: 2025-01-01\n"
+            "Summary: A great paper\nProblem: Hard problem\nMethod: Novel method\n"
+            "Innovation: Key insight\nResults: SOTA\nTags: NLP, LLM\nBenchmark: MMLU: 90"
+        )
+        result = parse_content_string(content)
+        assert result is not None
+        assert result["title"] == "My Paper"
+        assert result["authors"] == "Alice, Bob"
+        assert result["date"] == "2025-01-01"
+        assert result["summary"] == "A great paper"
+        assert result["tags"] == ["NLP", "LLM"]
+        assert result["benchmarks"] == ["MMLU: 90"]
+
+    def test_returns_none_without_title(self) -> None:
+        assert parse_content_string("Summary: No title here") is None
+
+    def test_returns_none_for_empty(self) -> None:
+        assert parse_content_string("") is None
+
+    def test_multiple_benchmarks(self) -> None:
+        content = "Title: T\nBenchmark: A: 10\nBenchmark: B: 20"
+        result = parse_content_string(content)
+        assert result is not None
+        assert result["benchmarks"] == ["A: 10", "B: 20"]
+
+
+class TestParseSearchResults:
+    def test_parses_json_block(self) -> None:
+        raw = (
+            "Some prefix\n"
+            "```json\n"
+            '{"reference_id": "", "content": "Title: DAPO\\nSummary: RL paper"}\n'
+            "```\nReference list..."
+        )
+        results = parse_search_results(raw)
+        assert len(results) == 1
+        assert results[0]["title"] == "DAPO"
+        assert results[0]["summary"] == "RL paper"
+
+    def test_parses_multiple_chunks(self) -> None:
+        raw = (
+            "```json\n"
+            '{"reference_id": "1", "content": "Title: Paper A\\nSummary: First"}\n'
+            '{"reference_id": "2", "content": "Title: Paper B\\nSummary: Second"}\n'
+            "```"
+        )
+        results = parse_search_results(raw)
+        assert len(results) == 2
+        assert results[0]["title"] == "Paper A"
+        assert results[1]["title"] == "Paper B"
+
+    def test_fallback_for_plain_text(self) -> None:
+        results = parse_search_results("Some plain text result")
+        assert len(results) == 1
+        assert results[0]["title"] == "Search Results"
+        assert "Some plain text" in results[0]["summary"]
+
+    def test_empty_input(self) -> None:
+        assert parse_search_results("") == []
+        assert parse_search_results("   ") == []
+
+    def test_skips_invalid_json_entries(self) -> None:
+        raw = (
+            "```json\n"
+            '{"reference_id": "1", "content": "Title: Good\\nSummary: OK"}\n'
+            "{bad json}\n"
+            "```"
+        )
+        results = parse_search_results(raw)
+        assert len(results) == 1
+        assert results[0]["title"] == "Good"


### PR DESCRIPTION
## Summary

- Add `parse_content_string` and `parse_search_results` to `dashboard/app.py` to parse LightRAG raw text output into structured paper dicts
- Update `/api/search-kg` to return `{"results": [...]}` as a list of paper objects
- Replace raw-text display in `search_kg.html` with DaisyUI cards showing title, date, authors, summary, tags, and benchmarks
- Add `TestParseContentString` and `TestParseSearchResults` test classes (48 tests pass)

## Test plan

- [x] `pytest tests/ -v` — 48 passed, 0 failed
- [x] Empty/whitespace question still returns `{"results": []}`
- [x] Plain-text fallback returns a single card with `"Search Results"` title
- [x] Multiple JSON chunks in one code block render as separate cards

Part of #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)